### PR TITLE
Add script to bootstrap new module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "precommit": "lint-staged",
     "prebuild": "rimraf build/",
     "build": "NODE_ENV=production rollup -c",
-    "test": "NODE_ENV=test ava"
+    "test": "NODE_ENV=test ava",
+    "new-module": "node scripts/bootstrap.js"
   },
   "ava": {
     "require": [

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -1,0 +1,113 @@
+/* eslint-disable no-console */
+const { promisify } = require('util');
+const fs = require('fs');
+const path = require('path');
+const { Transform } = require('stream');
+
+const ROOT_FOLDER = path.resolve(process.cwd(), 'src');
+
+const access = promisify(fs.access);
+const mkdir = promisify(fs.mkdir);
+
+/**
+ * Check if module already exists
+ * @param  {string}  moduleName Name of module
+ * @return {boolean}
+ */
+async function exists(moduleName) {
+  try {
+    const directoryPath = path.resolve(ROOT_FOLDER, moduleName);
+    await access(directoryPath);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Create the directory for the new module
+ * @param  {string}  moduleName Name of module
+ * @return {boolean}            If directory was created succsefully or not
+ */
+async function createModuleDirectory(moduleName) {
+  try {
+    const directoryPath = path.resolve(ROOT_FOLDER, moduleName);
+    await mkdir(directoryPath);
+
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Create new files from template
+ * @param  {string} template   Template name
+ * @param  {string} fileName   Name of new file
+ * @param  {string} moduleName Name of module
+ * @return {void}
+ */
+function createFile({ template, fileName, moduleName }) {
+  return new Promise((resolve, reject) => {
+    const transformer = new Transform({
+      transform(chunk, encoding, cb) {
+        const string = chunk.toString().replace(/module/g, moduleName);
+        this.push(Buffer.from(string));
+        cb();
+      },
+    });
+
+    const readStream = fs.createReadStream(
+      path.resolve(__dirname, 'templates', template),
+    );
+    const writeStream = fs.createWriteStream(
+      path.resolve(ROOT_FOLDER, moduleName, fileName),
+    );
+
+    readStream
+      .pipe(transformer)
+      .pipe(writeStream)
+      .on('finish', () => resolve())
+      .on('error', e => reject(e));
+  });
+}
+
+async function run(newModuleName) {
+  if (!newModuleName)
+    throw new Error('You must specify a module name as first argument');
+
+  try {
+    const alreadyExists = await exists(newModuleName);
+    if (alreadyExists) {
+      console.log(`The module '${newModuleName}' already exists.`);
+      return;
+    }
+
+    const directoryCreated = await createModuleDirectory(newModuleName);
+    if (!directoryCreated) {
+      console.log(
+        `Could not create a new directory for module '${newModuleName}'`,
+      );
+      return;
+    }
+
+    await createFile({
+      template: 'index.template.js',
+      fileName: 'index.js',
+      moduleName: newModuleName,
+    });
+
+    await createFile({
+      template: 'test.template.js',
+      fileName: `${newModuleName}.test.js`,
+      moduleName: newModuleName,
+    });
+
+    console.log(`Bootstraped new module '${newModuleName}'`);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+const [, , moduleName] = process.argv;
+run(moduleName);

--- a/scripts/templates/index.template.js
+++ b/scripts/templates/index.template.js
@@ -1,0 +1,1 @@
+export default () => null;

--- a/scripts/templates/test.template.js
+++ b/scripts/templates/test.template.js
@@ -1,0 +1,10 @@
+import test from 'ava';
+import module from '../module';
+
+test('Core.module', t => {
+  const should = 'Should ...';
+  const actual = module();
+  const expected = '';
+
+  t.is(actual, expected, should);
+});


### PR DESCRIPTION
Run `yarn run new-module moduleName` to bootsrap a new module.

The script will create a new folder named `moduleName` and also create
`index.js` and `moduleName.test.js` files.