### PR TITLE
Add feature find

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,10 @@
   "extends": ["airbnb-base", "plugin:flowtype/recommended", "prettier"],
   "plugins": ["flowtype", "prettier"],
   "rules": {
-    "prettier/prettier": ["error", { "singleQuote": true, "trailingComma": "all" }]
+    "prettier/prettier": [
+      "error",
+      { "singleQuote": true, "trailingComma": "all" }
+    ],
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }]
   }
 }

--- a/src/find/find.test.js
+++ b/src/find/find.test.js
@@ -1,0 +1,20 @@
+import test from 'ava';
+import find from '../find';
+
+test('Core.find', t => {
+  {
+    const should = 'Should find an element in an array based on a predicate';
+    const actual = find(n => n === 'b')(['a', 'b', 'c']);
+    const expected = 'b';
+
+    t.is(actual, expected, should);
+  }
+
+  {
+    const should = 'Should return undefined if no element is found';
+    const actual = find(n => n === 'd')(['a', 'b', 'c']);
+    const expected = undefined;
+
+    t.is(actual, expected, should);
+  }
+});

--- a/src/find/index.js
+++ b/src/find/index.js
@@ -1,0 +1,14 @@
+// @flow
+
+export default (predicateFn: (x: any) => boolean) => (arr: Array<any>) => {
+  let i = 0;
+  const len = arr.length;
+
+  while (i < len) {
+    const val = arr[i];
+    if (predicateFn(val)) return val;
+    i += 1;
+  }
+
+  return undefined;
+};

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@
 import _compose from './compose';
 import _curry from './curry';
 import _filter from './filter';
+import _find from './find';
 import _head from './head';
 import _isArray from './isArray';
 import _last from './last';
@@ -17,6 +18,7 @@ import _slice from './slice';
 export const compose = _compose;
 export const curry = _curry;
 export const filter = _filter;
+export const find = _find;
 export const head = _head;
 export const isArray = _isArray;
 export const last = _last;

--- a/src/reduce/index.js
+++ b/src/reduce/index.js
@@ -2,6 +2,6 @@
 
 export default (fn: GenericFn, init: any) => (arr: Array<any>) => {
   let l = init;
-  for (let i = 0; i < arr.length; i += 1) l = fn(l, arr[i]);
+  for (let i = 0; i < arr.length; i++) l = fn(l, arr[i]);
   return l;
 };

--- a/src/reduceRight/index.js
+++ b/src/reduceRight/index.js
@@ -2,6 +2,6 @@
 
 export default (fn: GenericFn, init: any) => (arr: Array<any>) => {
   let l = init;
-  for (let i = arr.length - 1; i >= 0; i -= 1) l = fn(l, arr[i]);
+  for (let i = arr.length - 1; i >= 0; i--) l = fn(l, arr[i]);
   return l;
 };


### PR DESCRIPTION
The `find`-module will return the first matching element of an array, based on a predicate function.

Example:
```js
const dinos = ['stegosauros', 'brontosauros', 't-rex'];
const findTRex = find(dino => dino === 't-rex');
const tRex = findTRex(dinos); // > tRex = 't-rex'
```

Also, this PR adds a small performance improvement to `reduce` and `reduceRight` (0ef5fa7).